### PR TITLE
Add support for -c -config (TOML config file) cli argument, with docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,9 @@ Open with with your preferred code editor
 9. **Config File Support:** Provide users with the ability to specify optional arguments in a [TOML](https://toml.io/en/) configuration file instead of passing them as command line arguments
 
 ## To Run Waypoint
+Waypoint uses the [tomllib](https://docs.python.org/3/library/tomllib.html) library, which was added to the Python Standard Library as of Python 3.11 via [PEP 680](https://peps.python.org/pep-0680/).
 
-**Please ensure you have Python installed.**
+**Please ensure you have Python 3.11 or later installed.**
 
 If not, please download it [here](https://www.python.org/downloads/).
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Open with with your preferred code editor
    - **Inline Code Blocks:** Enable users to include inline code with either single backticks (`) or triple backticks (```) and ensure proper code formatting.
    - **Horizontal Rules:** Offer support for horizontal rules to visually separate content sections in Markdown.
 
+9. **Config File Support:** Provide users with the ability to specify optional arguments in a [TOML](https://toml.io/en/) configuration file instead of passing them as command line arguments
 
 ## To Run Waypoint
 
@@ -66,5 +67,12 @@ If not, please download it [here](https://www.python.org/downloads/).
      ```
      python waypoint.py version.md -o newDirectory
      ```
-
-
+4. To pass a TOML-formatted config file when processing a file try the following
+      ```
+      python waypoint.py version.txt -c config.toml
+      ```
+   or
+      ```
+      python waypoint.py version.txt -config config.toml
+      ```
+   

--- a/config.toml
+++ b/config.toml
@@ -1,3 +1,3 @@
 output = "./build"
-# stylesheet = "https://cdn.jsdelivr.net/npm/water.css@2/out/water.css"
-# lang = "fr"
+stylesheet = "https://cdn.jsdelivr.net/npm/water.css@2/out/water.css"
+lang = "fr"

--- a/config.toml
+++ b/config.toml
@@ -1,0 +1,3 @@
+output = "./build"
+# stylesheet = "https://cdn.jsdelivr.net/npm/water.css@2/out/water.css"
+# lang = "fr"

--- a/waypoint.py
+++ b/waypoint.py
@@ -233,6 +233,7 @@ def set_config():
 
 def apply_config(data):
     input_path = sys.argv[1]
+    output_folder = "./waypoint" #if no output defined, use ./waypoint
     # search for and apply options one by one - currently only -o/-output flags supported
     # if "option-name" in data.keys():
         # option_to_enable = data["option-name"]

--- a/waypoint.py
+++ b/waypoint.py
@@ -230,9 +230,8 @@ def apply_config(data):
     # search for and apply options one by one - currently only -o/-output flags supported
     # if "option-name" in data.keys():
         # option_to_enable = data["option-name"]
-    if "output" in data.keys():
+    if "output" in data.keys(): # if output option was defined in TOML file
         output_folder  = data["output"]
-
     # convert files
     outputToDir(input_path, output_folder)
 

--- a/waypoint.py
+++ b/waypoint.py
@@ -195,8 +195,11 @@ def is_markdown(file_name):
 def parse_TOML(config_file):
     # parses input TOML-formatted config file
     with open(config_file, 'rb') as f:
-        data:dict = tomli.load(f)
-        return data
+        try:
+            data:dict = tomli.load(f)
+            return data
+        except tomli.TOMLDecodeError:
+            print("TOML FILE COULD NOT BE PARSED. PLEASE CHECK THE FORMAT")
 
 def set_config():
     # Parse config file, override all other flags

--- a/waypoint.py
+++ b/waypoint.py
@@ -234,11 +234,12 @@ def set_config():
 def apply_config(data):
     input_path = sys.argv[1]
     # search for and apply options one by one - currently only -o/-output flags supported
-    # if data["option-name"]
+    # if "option-name" in data.keys():
         # option_to_enable = data["option-name"]
-    if data["output"]:
+    if "output" in data.keys():
         output_folder  = data["output"]
 
+    # convert files
     outputToDir(input_path, output_folder)
 
 def main(): # this is the main function

--- a/waypoint.py
+++ b/waypoint.py
@@ -220,9 +220,7 @@ def set_config():
         print("NO CONFIG FILE PROVIDED")
     elif not os.path.exists(sys.argv[config_index+1]): # if provided argument is not valid
         print("CONFIG FILE DOES NOT EXIST")
-    elif os.path.isdir(sys.argv[config_index+1]): # if directory is provided
-        print("PLEASE PROVIDE A FILE")
-    elif not sys.argv[config_index+1].endswith(".toml"): # if non-TOML file is provided
+    elif os.path.isdir(sys.argv[config_index+1]) or not sys.argv[config_index+1].endswith(".toml"): # if directory or non-TOML file is provided
         print ("PLEASE PROVIDE A TOML FILE")
     else: # argument is a file that exists
         config_path = sys.argv[config_index+1]

--- a/waypoint.py
+++ b/waypoint.py
@@ -200,7 +200,10 @@ def parse_TOML(config_file):
     
 def main(): # this is the main function
     if len(sys.argv) > 1:
-        if sys.argv[1] == '-h' or sys.argv[1] == '-help':
+        if ('-c' in sys.argv) or ('-config' in sys.argv): # check for -c or -config flags
+            # Parse config file, override all other flags
+            print("checking for toml file")
+        elif sys.argv[1] == '-h' or sys.argv[1] == '-help':
             # Display help message
             print("Help message goes here.")
         elif sys.argv[1] == '-v' or sys.argv[1] == '-version':

--- a/waypoint.py
+++ b/waypoint.py
@@ -192,7 +192,12 @@ def write_markdown_to_html(new_content, new_title, ):
 def is_markdown(file_name):
     return (".md" in  file_name)
 
-
+def parse_TOML(config_file):
+    # parses input TOML-formatted config file
+    with open(config_file, 'rb') as f:
+        data:dict = tomli.load(f)
+        return data
+    
 def main(): # this is the main function
     if len(sys.argv) > 1:
         if sys.argv[1] == '-h' or sys.argv[1] == '-help':

--- a/waypoint.py
+++ b/waypoint.py
@@ -225,7 +225,10 @@ def set_config():
     else: # argument is a file that exists
         config_path = sys.argv[config_index+1]
         data:dict = parse_TOML(config_path)
-        print(data)
+        if not data: # if parse_TOML() failed
+            print("Could not parse provided config file. Please double-check passed file")
+        else:
+            print(data)
 
 def main(): # this is the main function
     if len(sys.argv) > 1:

--- a/waypoint.py
+++ b/waypoint.py
@@ -222,6 +222,8 @@ def set_config():
         print("CONFIG FILE DOES NOT EXIST")
     elif os.path.isdir(sys.argv[config_index+1]): # if directory is provided
         print("PLEASE PROVIDE A FILE")
+    elif not sys.argv[config_index+1].endswith(".toml"): # if non-TOML file is provided
+        print ("PLEASE PROVIDE A TOML FILE")
     else: # argument is a file that exists
         config_path = sys.argv[config_index+1]
         data:dict = parse_TOML(config_path)

--- a/waypoint.py
+++ b/waypoint.py
@@ -207,14 +207,6 @@ def set_config():
     config = "-c" if ('-c' in sys.argv) else "-config"
     config_index = sys.argv.index(config)
 
-    # to be deleted
-    print("reading config file")
-    print("There are this many arguments:")
-    print(len(sys.argv))
-    print("config argument is ")
-    print(config)
-    print("config file should be at")
-    print(config_index+1)
     # config file path immediately follows -c or -config flag
     if len(sys.argv) == config_index+1: # if no argument follows config flag
         print("NO CONFIG FILE PROVIDED")

--- a/waypoint.py
+++ b/waypoint.py
@@ -204,10 +204,11 @@ def parse_TOML(config_file):
 def set_config():
     # Parse config file, override all other flags
     print("checking for toml file")
+    # store config string argument
     config = "-c" if ('-c' in sys.argv) else "-config"
+    # store config string's index location in sys.argv
     config_index = sys.argv.index(config)
-
-    # config file path immediately follows -c or -config flag
+    # config file path immediately follows -c or -config flag (config file will exist in sys.argv[config_index+1])
     if len(sys.argv) == config_index+1: # if no argument follows config flag
         print("NO CONFIG FILE PROVIDED")
     elif not os.path.exists(sys.argv[config_index+1]): # if provided argument is not valid
@@ -216,11 +217,11 @@ def set_config():
         print ("PLEASE PROVIDE A TOML FILE")
     else: # argument is a file that exists
         config_path = sys.argv[config_index+1]
-        data:dict = parse_TOML(config_path)
+        data:dict = parse_TOML(config_path) # parse TOML file and store in data
         if not data: # if parse_TOML() failed
             print("Could not parse provided config file. Please double-check passed file")
         else:
-            print(data)
+            # apply config options inside data
             apply_config(data)
 
 def apply_config(data):

--- a/waypoint.py
+++ b/waypoint.py
@@ -204,6 +204,24 @@ def set_config():
     config = "-c" if ('-c' in sys.argv) else "-config"
     config_index = sys.argv.index(config)
 
+    # to be deleted
+    print("reading config file")
+    print("There are this many arguments:")
+    print(len(sys.argv))
+    print("config argument is ")
+    print(config)
+    print("config file should be at")
+    print(config_index+1)
+    # config file path immediately follows -c or -config flag
+    if len(sys.argv) == config_index+1: # if no argument follows config flag
+        print("NO CONFIG FILE PROVIDED")
+    elif not os.path.exists(sys.argv[config_index+1]): # if provided argument is not valid
+        print("CONFIG FILE DOES NOT EXIST")
+    else: # argument is a file that exists
+        config_path = sys.argv[config_index+1]
+        data:dict = parse_TOML(config_path)
+        print(data)
+
 def main(): # this is the main function
     if len(sys.argv) > 1:
         if ('-c' in sys.argv) or ('-config' in sys.argv): # check for -c or -config flags

--- a/waypoint.py
+++ b/waypoint.py
@@ -197,15 +197,17 @@ def parse_TOML(config_file):
     with open(config_file, 'rb') as f:
         data:dict = tomli.load(f)
         return data
-    
+
+def set_config():
+    # Parse config file, override all other flags
+    print("checking for toml file")
+    config = "-c" if ('-c' in sys.argv) else "-config"
+    config_index = sys.argv.index(config)
+
 def main(): # this is the main function
     if len(sys.argv) > 1:
         if ('-c' in sys.argv) or ('-config' in sys.argv): # check for -c or -config flags
-            # Parse config file, override all other flags
-            print("checking for toml file")
-            config = "-c" if ('-c' in sys.argv) else "-config"
-            config_index = sys.argv.index(config)
-
+            set_config()
         elif sys.argv[1] == '-h' or sys.argv[1] == '-help':
             # Display help message
             print("Help message goes here.")

--- a/waypoint.py
+++ b/waypoint.py
@@ -203,6 +203,9 @@ def main(): # this is the main function
         if ('-c' in sys.argv) or ('-config' in sys.argv): # check for -c or -config flags
             # Parse config file, override all other flags
             print("checking for toml file")
+            config = "-c" if ('-c' in sys.argv) else "-config"
+            config_index = sys.argv.index(config)
+
         elif sys.argv[1] == '-h' or sys.argv[1] == '-help':
             # Display help message
             print("Help message goes here.")

--- a/waypoint.py
+++ b/waypoint.py
@@ -217,6 +217,8 @@ def set_config():
         print("NO CONFIG FILE PROVIDED")
     elif not os.path.exists(sys.argv[config_index+1]): # if provided argument is not valid
         print("CONFIG FILE DOES NOT EXIST")
+    elif os.path.isdir(sys.argv[config_index+1]): # if directory is provided
+        print("PLEASE PROVIDE A FILE")
     else: # argument is a file that exists
         config_path = sys.argv[config_index+1]
         data:dict = parse_TOML(config_path)

--- a/waypoint.py
+++ b/waypoint.py
@@ -1,7 +1,7 @@
 
 import os
 import sys
-
+import tomli
 VERSION = "2" # current version of the tool
 
 def process_folder(folder_path):

--- a/waypoint.py
+++ b/waypoint.py
@@ -229,6 +229,17 @@ def set_config():
             print("Could not parse provided config file. Please double-check passed file")
         else:
             print(data)
+            apply_config(data)
+
+def apply_config(data):
+    input_path = sys.argv[1]
+    # search for and apply options one by one - currently only -o/-output flags supported
+    # if data["option-name"]
+        # option_to_enable = data["option-name"]
+    if data["output"]:
+        output_folder  = data["output"]
+
+    outputToDir(input_path, output_folder)
 
 def main(): # this is the main function
     if len(sys.argv) > 1:

--- a/waypoint.py
+++ b/waypoint.py
@@ -1,7 +1,7 @@
 
 import os
 import sys
-import tomli
+import tomllib
 VERSION = "2" # current version of the tool
 
 def process_folder(folder_path):
@@ -196,9 +196,9 @@ def parse_TOML(config_file):
     # parses input TOML-formatted config file
     with open(config_file, 'rb') as f:
         try:
-            data:dict = tomli.load(f)
+            data:dict = tomllib.load(f)
             return data
-        except tomli.TOMLDecodeError:
+        except tomllib.TOMLDecodeError:
             print("TOML FILE COULD NOT BE PARSED. PLEASE CHECK THE FORMAT")
 
 def set_config():


### PR DESCRIPTION
## Change Summary

This fixes #16.

I've added config (`-c, -config`) support to Waypoint.
When adding TOML support I originally used the `tomli` library but later learned a version of `tomli`, `tomllib` was added to the Python standard since Python 3.11 and used `tomllib` instead, to avoid requiring users to install external packages.
However, users will require `Python 3.11` or later to run `Waypoint`.

### New Files
Added the following files:
- `config.toml` - a TOML file with test options - the only relevant one is `output` as it's the only optional flag currently supported (`-h`/`-help` and `-v`/`-version` are used on their own).

### File Modifications

#### `Waypoint.py`

##### New Methods
I added the following methods to `Waypoint.py`:
- `parse_TOML(config_file)`: Uses `tomllib.load()` to parse input config_file (a TOML file) and returns a `dictionary`
- `set_config()`: Entry point for config flag (`-c`, `-config`) support, executes when config flags are detected and applies config support logic
- `apply_config(data)`: Reads `dictionary` returned from `parse_TOML(config_file) and applies supported options provided in the config file to current conversion

##### Changes to `main()`
- I modified the 'flag handling' `if/else` structure in `main()` to check for config flags (`-c`, `-config`) as these flags should override all other present flags.

#### `README.md`
- I also updated the `README.md` file with the updates I made and the requirement for `Python 3.11` or above.

---
## Bugs and Warnings

### `outputToDir()`
Before making my additions, I noticed that the `outputToDir(file_path, outputpath)` method does not support `directory` handling. This means that the `output` flags (`-o`, `-output`) do not support `directory` handling.
As `apply_config(data)` uses `outputToDir()` to convert input files, the `-c` and `-config` flags will also fail if a `directory` is the conversion target.

I believe extended `outputToDir()` with `directory` handling will solve both issues, but is beyond the scope of this issue/PR.

### `apply_config`
`apply_config(data)` currently only supports `output` options, and will ignore other options inside the input `TOML` file until support for them is added.
When support for additional options are added to `Waypoint`, `apply_config` must be updated with support for those new options.